### PR TITLE
Handle constructors

### DIFF
--- a/src/main/java/com/github/zastai/apiref/formatters/CodeFormatter.java
+++ b/src/main/java/com/github/zastai/apiref/formatters/CodeFormatter.java
@@ -221,6 +221,7 @@ public abstract class CodeFormatter {
    * <p>
    * This consists of:
    * <ol>
+   *   <li>Any constructors declared by the class (via {@link #writeConstructorList(Collection)}).</li>
    *   <li>Any fields declared by the class (via {@link #writeFieldList(Collection)}).</li>
    *   <li>Any methods declared by the class (via {@link #writeMethodList(Collection)}).</li>
    *   <li>Any types nested inside the class (via {@link #writeNestedClassList(Collection)}).</li>
@@ -230,6 +231,7 @@ public abstract class CodeFormatter {
    */
   protected void writeClassContents(@NotNull JavaClass jc) {
     // FIXME: We might need to pass the ClassNode through too.
+    this.writeConstructorList(jc.constructors);
     this.writeFieldList(jc.fields);
     this.writeMethodList(jc.methods);
     this.writeNestedClassList(jc.nestedClasses());
@@ -259,6 +261,58 @@ public abstract class CodeFormatter {
    * @param type The type.
    */
   protected abstract void writeClassName(@NotNull Type type);
+
+  /**
+   * Writes out a single constructor.
+   *
+   * @param mn The node for the constructor.
+   */
+  protected void writeConstructor(@NotNull MethodNode mn) {
+    // A constructor is just a method in the end.
+    this.writeMethod(mn);
+  }
+
+  /**
+   * Writes out a list of constructor; this consists of a header (via {@link #writeConstructorListHeader(Collection)}), its contents
+   * (via {@link #writeConstructorListContents(Collection)}), and a footer (via {@link #writeConstructorListFooter(Collection)}).
+   *
+   * @param list The methods.
+   */
+  protected void writeConstructorList(@NotNull Collection<MethodNode> list) {
+    if (list.isEmpty()) {
+      return;
+    }
+    this.writeConstructorListHeader(list);
+    this.writeConstructorListContents(list);
+    this.writeConstructorListFooter(list);
+  }
+
+  /**
+   * Writes out the contents of a list of constructors (via {@link #writeConstructor(MethodNode)}).
+   *
+   * @param list The list of constructors.
+   */
+  protected void writeConstructorListContents(@NotNull Collection<MethodNode> list) {
+    list.forEach(this::writeConstructor);
+  }
+
+  /**
+   * Writes out a footer for a list of constructors.
+   *
+   * @param list The list of constructors.
+   */
+  protected void writeConstructorListFooter(@NotNull Collection<MethodNode> list) {
+    // default: no footer
+  }
+
+  /**
+   * Writes out a header for a list of constructors.
+   *
+   * @param list The list of constructors.
+   */
+  protected void writeConstructorListHeader(@NotNull Collection<MethodNode> list) {
+    // default: no header
+  }
 
   /** Writes out the end of a set of enum values. */
   protected void writeEndOfEnumValues() {

--- a/src/main/java/com/github/zastai/apiref/model/JavaClass.java
+++ b/src/main/java/com/github/zastai/apiref/model/JavaClass.java
@@ -3,6 +3,7 @@ package com.github.zastai.apiref.model;
 import com.github.zastai.apiref.internal.ASMUtil;
 import com.github.zastai.apiref.internal.Constants;
 import com.github.zastai.apiref.internal.Util;
+import com.github.zastai.apiref.internal.WellKnown;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.asm.Opcodes;
@@ -18,6 +19,10 @@ import java.util.TreeSet;
 
 /** A Java class. */
 public class JavaClass {
+
+  /** The (externally visible) constructors provided by the class. */
+  @NotNull
+  public final SortedSet<MethodNode> constructors;
 
   /** The loaded class contents. */
   @NotNull
@@ -72,10 +77,19 @@ public class JavaClass {
       this.fields = Collections.emptySortedSet();
     }
     if (cn.methods != null) {
+      this.constructors = new TreeSet<>(JavaClass::compare);
       this.methods = new TreeSet<>(JavaClass::compare);
-      cn.methods.stream().filter(mn -> JavaClass.isRelevant(cn, mn, verbose)).forEach(this.methods::add);
+      cn.methods.stream().filter(mn -> JavaClass.isRelevant(cn, mn, verbose)).forEach(mn -> {
+        if (WellKnown.Names.CONSTRUCTOR.equals(mn.name)) {
+          this.constructors.add(mn);
+        }
+        else {
+          this.methods.add(mn);
+        }
+      });
     }
     else {
+      this.constructors = Collections.emptySortedSet();
       this.methods = Collections.emptySortedSet();
     }
   }


### PR DESCRIPTION
The constructors for a class are now gathered in a list separate from other methods. They are emitted at the top of the class, before the fields. A return type is no longer included.

Fixes #19.